### PR TITLE
Function rove/core/result:assertion-description was transformed into generic.

### DIFF
--- a/core/assertion.lisp
+++ b/core/assertion.lisp
@@ -133,6 +133,11 @@
                (t 'passed-assertion))))))
 
 (defmacro signals (form &optional (condition ''error))
+  "Returns t if given form raise condition of given type,
+   and nil otherwise.
+
+   Warning:
+   Use only in conjunction with `ok' macro to build an assertion."
   (let ((c (gensym))
         (condition-type (gensym)))
     `(let ((,condition-type ,condition))

--- a/core/result.lisp
+++ b/core/result.lisp
@@ -85,7 +85,15 @@
     (declare (ignore values))
     (format nil "Expect ~A to be false." (first args))))
 
-(defun assertion-description (assertion)
+(defgeneric assertion-description (assertion)
+  (:documentation "Returns a string to print description of
+                   an object of class `assertion'.
+
+                   Useful, when you write your own assertions based
+                   on Rove's and want to customize their representation
+                   in test results."))
+
+(defmethod assertion-description ((assertion t))
   (with-slots (desc form values) assertion
     (or desc
         ;; Default description


### PR DESCRIPTION
This is useful, when you write your own assertions based on Rove's and want to customize their representation in test results.