### PR TITLE
Fix defhook

### DIFF
--- a/core/test.lisp
+++ b/core/test.lisp
@@ -61,10 +61,10 @@
 (defmacro defhook (mode &body body)
   (let ((main (gensym "MAIN")))
     `(flet ((,main () ,@body))
-       (pushnew ',main
+       (pushnew #',main
                 ,(ecase mode
-                   (:before `(suite-before-hooks *package*))
-                   (:after `(suite-after-hooks *package*)))))))
+                   (:before `(suite-before-hooks (package-suite *package*)))
+                   (:after `(suite-after-hooks (package-suite *package*))))))))
 
 (defun package-tests (package)
   (reverse (suite-tests (package-suite package))))


### PR DESCRIPTION
When I tried rove, the `defhook` failed because of type error.

As far as I can see, there are the following 2 problems (the first relates to the type error, the second is another issue). This patch is for them.

- The suite-before-hooks (suite-after-hooks) wrongly takes a package as its argument.
- A callback of hooks is wrongly registered as a mere symbol not as a function value.