### PR TITLE
Fix to enable lexical functions and macros in "ok" ("ng") clause

### DIFF
--- a/core/assertion.lisp
+++ b/core/assertion.lisp
@@ -32,7 +32,7 @@
       (list form)))
 
 (defparameter *fail* '#:interrupt-with-error)
-(defmacro form-inspect (form)
+(defmacro form-inspect (form &environment env)
   (let ((args-symbols (gensym "ARGS-SYMBOLS"))
         (args-values (gensym "ARGS-VALUES"))
         (result (gensym "RESULT"))
@@ -42,7 +42,7 @@
     (if (and (consp form)
              (symbolp (first form))
              (not (special-operator-p (first form)))
-             (not (macro-function (first form))))
+             (not (macro-function (first form) env)))
         `(let* (,args-symbols
                 ,args-values
                 (,result
@@ -56,7 +56,7 @@
                               ,res)))))
            (values (if (find *fail* ,result :test 'eq)
                        *fail*
-                       (restart-case (apply ',(first form) ,result)
+                       (restart-case (apply #',(first form) ,result)
                          (cont () *fail*)))
                    ,args-symbols
                    ,args-values))


### PR DESCRIPTION
When using functions and macros defined in lexical environment as the following examples, they throw "undefined function" error.

```lisp
(deftest lexical-func
  (flet ((some-func () 100))
    (ok (= (some-func) 100))))

(deftest lexical-macro
  (macrolet ((some-macro () 200))
    (ok (= (some-macro) 200))))
```

This patch adds `&environment` to `rove/core/assertion::form-inspect` to enable to search macros in lexical environment. And it fixes to explicitly extract function objects when applying for lexical functions.