### PR TITLE
Make COVERAGE-ENABLED-P return a boolean, not (or integer null)

### DIFF
--- a/roswell/rove.ros
+++ b/roswell/rove.ros
@@ -19,7 +19,7 @@ exec ros -Q -- $0 "$@"
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defun coverage-enabled-p ()
     (and (stringp (uiop:getenv "COVERAGE"))
-         (string/= (uiop:getenv "COVERAGE") ""))))
+         (not (null (string/= (uiop:getenv "COVERAGE") ""))))))
 
 (defun get-real-stream (stream)
   (if (typep stream 'synonym-stream)


### PR DESCRIPTION
I was getting errors about asdf being called with a key parameter `:force 0`.  After investigating, it turns out that `STRING/=` will return the number of characters in common between the two strings if they're different, which, when comparing to `""` is always 0. (eg. `(string/= anything "") === 0`)

So, this converts its return value to `(member null t)` so it behaves as I think was expected with asdf operations.