### PR TITLE
Allow to change the compile time of the body of DEFTEST.

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -17,7 +17,8 @@
                 #:testing
                 #:setup
                 #:teardown
-                #:defhook)
+                #:defhook
+                #:*default-test-compilation-time*)
   (:import-from #:rove/core/suite
                 #:run-system-tests
                 #:run-suite


### PR DESCRIPTION
It's equivalent to FiveAM's `:compile-at` option.