### PR TITLE
Fix resolve-file for Windows.

### DIFF
--- a/core/suite/file.lisp
+++ b/core/suite/file.lisp
@@ -26,7 +26,11 @@
            :type "lisp"
            :defaults pathname
            :directory (cons :absolute
-                            (nthcdr (length (pathname-directory asdf:*user-cache*))
+                            (nthcdr (+ (length (pathname-directory asdf:*user-cache*))
+                                       ;; Omit also pathname-device
+                                       (if (pathname-device pathname)
+                                           1
+                                           0))
                                     (pathname-directory pathname))))
           (uiop:lispize-pathname pathname)))))
 


### PR DESCRIPTION
This bug leads to run no tests on Windows.