### PR TITLE
Fix resolve-file to work on the Mac

### DIFF
--- a/core/suite/file.lisp
+++ b/core/suite/file.lisp
@@ -24,7 +24,8 @@
                0)
           (let* ((directories (nthcdr (length (pathname-directory asdf:*user-cache*))
                                       (pathname-directory pathname)))
-                 (device (when (pathname-device pathname)
+                 (device (pathname-device pathname))
+                 (device (when (and device (not (eq device :unspecific)))
                            (pop directories))))
             (make-pathname
              :type "lisp"


### PR DESCRIPTION
`pathname-device` returns `:UNSPECIFIC` instead of `NIL` on the Mac. As a result, the top directory in the path gets popped during file resolution and the wrong path is stored in the `*file-package*` hash table. This patch fixes the issue and makes tests work on the Mac.