### PR TITLE
Check that the test name is a symbol before registering the test.

### DIFF
--- a/core/suite/package.lisp
+++ b/core/suite/package.lisp
@@ -62,6 +62,7 @@
   (get name 'test))
 
 (defun set-test (name test-fn)
+  (check-type name symbol)
   (pushnew name (suite-tests (package-suite *package*))
            :test 'eq)
   (setf (get name 'test) test-fn)


### PR DESCRIPTION
Since tests are set on the test property of the test name (i.e. with
GET), if the name is not a symbol the registration will fail. But
since the prior step will have registered the test with the package
suite, whenever the suite for that package is run later it will signal
an error. This way, the error prevents the bogus tests from being
registered and corrupting the package suite.