### PR TITLE
Fix calculation of test duration.

### DIFF
--- a/core/assertion.lisp
+++ b/core/assertion.lisp
@@ -103,7 +103,9 @@
                         (setf ,result ,res)
                         (setf ,values ,vals)
                         (setf ,args ,symbs))
-                      (setf ,duration (- (get-internal-real-time) ,start)))
+                      ;; Duration is in milliseconds.
+                      (setf ,duration (truncate (- (get-internal-real-time) ,start)
+                                                (/ internal-time-units-per-second 1000))))
                     (if (eq ,result *fail*)
                         (progn
                           (record *stats* (make-assertion ,reason ,stacks))


### PR DESCRIPTION
Test duration is in milliseconds, but it is calculated using internal
time units. On implementations where INTERNAL-TIME-UNITS-PER-SECOND is
not 1000, this will produce wildly inflated test duration values in
the reports. This fixes the calculation to account for varying time
resolution in implementations so that test duration is always in
milliseconds.

Example on SBCL:
```
(rove:ok (or (sleep 3) t))
✓ Expect (OR (SLEEP 3) T) to be true. (3000009ms)
T
```