### PR TITLE
Revise Rove internals

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -159,9 +159,14 @@ Use `(defhook :after ...)` instead for running after each test.
   (uiop:delete-directory-tree *tmp-directory* validate t :if-does-not-exist :ignore))
 ```
 
-### defhook (mode &body body)
+### defhook (name mode &body body)
 
 Evaluates before/after running a each test in the package.
+
+```common-lisp
+(defhook my-db-hook :before
+  ...)
+```
 
 ### run (package &key style env)
 

--- a/core/result.lisp
+++ b/core/result.lisp
@@ -22,6 +22,7 @@
 
            #:test
            #:test-name
+           #:test-description
            #:passed-tests
            #:failed-tests
            #:pending-tests
@@ -120,6 +121,8 @@
 (defclass test ()
   ((name :initarg :name
          :reader test-name)
+   (description :initarg :description
+                :reader test-description)
    (passed :initarg :passed
            :initform nil
            :accessor test-passed-tests)

--- a/core/result.lisp
+++ b/core/result.lisp
@@ -1,5 +1,6 @@
 (in-package #:cl-user)
-(defpackage #:rove/core/result
+(defpackage #:rove/result
+  (:nicknames #:rove/core/result)
   (:use #:cl)
   (:export #:passed
            #:failed

--- a/core/result.lisp
+++ b/core/result.lisp
@@ -131,6 +131,13 @@
             :initform nil
             :accessor test-pending-tests)))
 
+(defmethod print-object ((test test) stream)
+  (print-unreadable-object (test stream :type t)
+    (format stream "~A (PASSED=~D, FAILED=~D)"
+            (test-name test)
+            (length (test-passed-tests test))
+            (length (test-failed-tests test)))))
+
 (defgeneric passedp (object)
   (:method ((object test))
     (= 0 (length (test-failed-tests object)))))

--- a/core/result.lisp
+++ b/core/result.lisp
@@ -26,7 +26,7 @@
            #:passed-tests
            #:failed-tests
            #:pending-tests
-           #:test-passed-p
+           #:passedp
 
            #:passed-assertion
            #:failed-assertion
@@ -123,17 +123,27 @@
          :reader test-name)
    (passed :initarg :passed
            :initform nil
-           :accessor passed-tests)
+           :accessor test-passed-tests)
    (failed :initarg :failed
            :initform nil
-           :accessor failed-tests)
+           :accessor test-failed-tests)
    (pending :initarg :pending
             :initform nil
-            :accessor pending-tests)))
+            :accessor test-pending-tests)))
 
-(defgeneric test-passed-p (test)
-  (:method ((test test))
-    (= 0 (length (failed-tests test)))))
+(defgeneric passedp (object)
+  (:method ((object test))
+    (= 0 (length (test-failed-tests object)))))
+
+(defgeneric passed-tests (object)
+  (:method ((object test))
+    (test-passed-tests object)))
+(defgeneric failed-tests (object)
+  (:method ((object test))
+    (test-failed-tests object)))
+(defgeneric pending-tests (object)
+  (:method ((object test))
+    (test-pending-tests object)))
 
 (defclass passed-assertion (assertion passed) ())
 (defclass failed-assertion (assertion failed) ())

--- a/core/result.lisp
+++ b/core/result.lisp
@@ -1,6 +1,5 @@
 (in-package #:cl-user)
-(defpackage #:rove/result
-  (:nicknames #:rove/core/result)
+(defpackage #:rove/core/result
   (:use #:cl)
   (:export #:passed
            #:failed

--- a/core/result.lisp
+++ b/core/result.lisp
@@ -23,9 +23,9 @@
 
            #:test
            #:test-name
-           #:test-passed-assertions
-           #:test-failed-assertions
-           #:test-pending-assertions
+           #:passed-tests
+           #:failed-tests
+           #:pending-tests
            #:test-passed-p
 
            #:passed-assertion
@@ -123,17 +123,17 @@
          :reader test-name)
    (passed :initarg :passed
            :initform nil
-           :accessor test-passed-assertions)
+           :accessor passed-tests)
    (failed :initarg :failed
            :initform nil
-           :accessor test-failed-assertions)
+           :accessor failed-tests)
    (pending :initarg :pending
             :initform nil
-            :accessor test-pending-assertions)))
+            :accessor pending-tests)))
 
 (defgeneric test-passed-p (test)
   (:method ((test test))
-    (= 0 (length (test-failed-assertions test)))))
+    (= 0 (length (failed-tests test)))))
 
 (defclass passed-assertion (assertion passed) ())
 (defclass failed-assertion (assertion failed) ())

--- a/core/stats.lisp
+++ b/core/stats.lisp
@@ -7,6 +7,7 @@
            #:stats
            #:stats-plan
            #:stats-context
+           #:stats-result
            #:stats-context-labels
            #:context-test-count
            #:record
@@ -64,6 +65,11 @@
   (:method ((stats stats))
     (or (first (slot-value stats 'contexts))
         stats)))
+
+(defun stats-result (stats)
+  (if (/= (length (stats-failed-tests stats)) 0)
+      (aref (stats-failed-tests *stats*) 0)
+      (aref (stats-passed-tests *stats*) 0)))
 
 (defgeneric stats-context-labels (stats)
   (:documentation "Returns the labels of the current contexts (including nested ones)")
@@ -163,11 +169,12 @@
   (:method (stats)
     (declare (ignore stats)))
   (:method :before (stats)
-    (with-slots (passed failed pending plan) stats
+    (with-slots (passed failed pending plan contexts) stats
       (setf passed (make-array 0 :adjustable t :fill-pointer 0)
             failed (make-array 0 :adjustable t :fill-pointer 0)
             pending (make-array 0 :adjustable t :fill-pointer 0)
-            plan nil))))
+            plan nil
+            contexts nil))))
 
 (defgeneric summarize (stats)
   (:method (stats)

--- a/core/stats.lisp
+++ b/core/stats.lisp
@@ -15,6 +15,8 @@
            #:plan
            #:test-begin
            #:test-finish
+           #:suite-begin
+           #:suite-finish
            #:toplevel-stats-p
            #:all-failed-assertions))
 (in-package #:rove/core/stats)
@@ -116,6 +118,13 @@
         (record stats test)
 
         (values passedp context)))))
+
+(defgeneric suite-begin (stats suite-name)
+  (:method (stats suite-name)
+    (values)))
+
+(defgeneric suite-finish (stats suite-name)
+  (:method (stats suite-name)))
 
 (defun toplevel-stats-p (stats)
   (null (slot-value stats 'contexts)))

--- a/core/stats.lisp
+++ b/core/stats.lisp
@@ -68,8 +68,8 @@
 
 (defun stats-result (stats)
   (if (/= (length (stats-failed-tests stats)) 0)
-      (aref (stats-failed-tests *stats*) 0)
-      (aref (stats-passed-tests *stats*) 0)))
+      (aref (stats-failed-tests stats) 0)
+      (aref (stats-passed-tests stats) 0)))
 
 (defgeneric stats-context-labels (stats)
   (:documentation "Returns the labels of the current contexts (including nested ones)")

--- a/core/stats.lisp
+++ b/core/stats.lisp
@@ -1,12 +1,10 @@
 (in-package #:cl-user)
-(defpackage #:rove/core/stats
+(defpackage #:rove/stats
+  (:nicknames #:rove/core/stats)
   (:use #:cl
         #:rove/core/result)
   (:export #:*stats*
            #:stats
-           #:stats-passed
-           #:stats-failed
-           #:stats-pending
            #:stats-plan
            #:stats-context
            #:stats-context-labels
@@ -15,7 +13,6 @@
            #:plan
            #:test-begin
            #:test-finish
-           #:stats-passed-p
            #:with-context
            #:suite-begin
            #:suite-finish
@@ -30,11 +27,11 @@
 
 (defclass stats ()
   ((passed :initform (make-array 0 :adjustable t :fill-pointer 0)
-           :accessor stats-passed)
+           :accessor stats-passed-tests)
    (failed :initform (make-array 0 :adjustable t :fill-pointer 0)
-           :accessor stats-failed)
+           :accessor stats-failed-tests)
    (pending :initform (make-array 0 :adjustable t :fill-pointer 0)
-            :accessor stats-pending)
+            :accessor stats-pending-tests)
    (plan :initarg :plan
          :initform nil
          :accessor stats-plan)
@@ -49,8 +46,17 @@
 (defmethod print-object ((stats stats) stream)
   (print-unreadable-object (stats stream :type t)
     (format stream "PASSED=~D, FAILED=~D"
-            (length (stats-passed stats))
-            (length (stats-failed stats)))))
+            (length (stats-passed-tests stats))
+            (length (stats-failed-tests stats)))))
+
+(defmethod passed-tests ((object stats))
+  (coerce (stats-passed-tests object) 'list))
+
+(defmethod failed-tests ((object stats))
+  (coerce (stats-failed-tests object) 'list))
+
+(defmethod pending-tests ((object stats))
+  (coerce (stats-pending-tests object) 'list))
 
 (defgeneric stats-context (stats)
   (:documentation "Returns the current stats to record.")
@@ -70,9 +76,9 @@
 
 (defgeneric context-test-count (context)
   (:method ((context stats))
-    (+ (length (stats-failed context))
-       (length (stats-passed context))
-       (length (stats-pending context)))))
+    (+ (length (stats-failed-tests context))
+       (length (stats-passed-tests context))
+       (length (stats-pending-tests context)))))
 
 (defun new-context (stats test-name)
   (let ((context (make-instance 'stats :name test-name)))
@@ -84,11 +90,11 @@
 
 (defgeneric record (stats object)
   (:method ((stats stats) (object passed))
-    (vector-push-extend object (stats-passed (stats-context stats))))
+    (vector-push-extend object (stats-passed-tests (stats-context stats))))
   (:method ((stats stats) (object failed))
-    (vector-push-extend object (stats-failed (stats-context stats))))
+    (vector-push-extend object (stats-failed-tests (stats-context stats))))
   (:method ((stats stats) (object pending))
-    (vector-push-extend object (stats-pending (stats-context stats))))
+    (vector-push-extend object (stats-pending-tests (stats-context stats))))
   (:method ((stats null) object)
     (declare (ignore object))))
 
@@ -104,13 +110,13 @@
   (:method (stats test-name)
     (declare (ignore stats test-name))))
 
-(defun stats-passed-p (stats)
-  (and (= 0 (length (stats-failed stats)))
+(defmethod passedp ((stats stats))
+  (and (= 0 (length (stats-failed-tests stats)))
        (or (null (stats-plan stats))
            (= (stats-plan stats)
-              (+ (length (stats-failed stats))
-                 (length (stats-passed stats))
-                 (length (stats-pending stats)))))))
+              (+ (length (stats-failed-tests stats))
+                 (length (stats-passed-tests stats))
+                 (length (stats-pending-tests stats)))))))
 
 (defmacro with-context ((context &key name) &body body)
   (let ((passedp (gensym "PASSEDP"))
@@ -119,20 +125,20 @@
        (declare (ignorable ,context))
        (unwind-protect (progn ,@body)
          (let* ((,context (stats-context *stats*))
-                (,passedp (and (= 0 (length (stats-failed ,context)))
+                (,passedp (and (= 0 (length (stats-failed-tests ,context)))
                                (or (null (stats-plan ,context))
                                    (= (stats-plan ,context)
-                                      (+ (length (stats-failed ,context))
-                                         (length (stats-passed ,context))
-                                         (length (stats-pending ,context)))))))
+                                      (+ (length (stats-failed-tests ,context))
+                                         (length (stats-passed-tests ,context))
+                                         (length (stats-pending-tests ,context)))))))
                 (,test
                   (make-instance (if ,passedp
                                      'passed-test
                                      'failed-test)
                                  :name ,name
-                                 :passed (coerce (stats-passed (stats-context *stats*)) 'list)
-                                 :failed (coerce (stats-failed (stats-context *stats*)) 'list)
-                                 :pending (coerce (stats-pending (stats-context *stats*)) 'list))))
+                                 :passed (coerce (stats-passed-tests (stats-context *stats*)) 'list)
+                                 :failed (coerce (stats-failed-tests (stats-context *stats*)) 'list)
+                                 :pending (coerce (stats-pending-tests (stats-context *stats*)) 'list))))
            (leave-context *stats*)
            (record *stats* ,test))))))
 
@@ -162,4 +168,4 @@
 (defun all-failed-assertions (stats)
   (loop for context in (cons stats
                              (slot-value stats 'contexts))
-        append (coerce (stats-failed context) 'list)))
+        append (coerce (stats-failed-tests context) 'list)))

--- a/core/stats.lisp
+++ b/core/stats.lisp
@@ -109,13 +109,13 @@
   (check-type count integer)
   (setf (stats-plan (stats-context *stats*)) count))
 
-(defgeneric test-begin (stats test-name &optional count)
-  (:method (stats test-name &optional count)
-    (declare (ignore stats test-name count))))
+(defgeneric test-begin (stats description &optional count)
+  (:method (stats description &optional count)
+    (declare (ignore stats description count))))
 
-(defgeneric test-finish (stats test-name)
-  (:method (stats test-name)
-    (declare (ignore stats test-name))))
+(defgeneric test-finish (stats description)
+  (:method (stats description)
+    (declare (ignore stats description))))
 
 (defmethod passedp ((stats stats))
   (and (= 0 (length (stats-failed-tests stats)))
@@ -125,10 +125,10 @@
                  (length (stats-passed-tests stats))
                  (length (stats-pending-tests stats)))))))
 
-(defmacro with-context ((context &key name) &body body)
+(defmacro with-context ((context &key name description) &body body)
   (let ((passedp (gensym "PASSEDP"))
         (test (gensym "TEST")))
-    `(let ((,context (new-context *stats* ,name)))
+    `(let ((,context (new-context *stats* ',name)))
        (declare (ignorable ,context))
        (unwind-protect (progn ,@body)
          (let* ((,context (stats-context *stats*))
@@ -142,7 +142,8 @@
                   (make-instance (if ,passedp
                                      'passed-test
                                      'failed-test)
-                                 :name ,name
+                                 :name ',name
+                                 :description ,description
                                  :passed (coerce (stats-passed-tests (stats-context *stats*)) 'list)
                                  :failed (coerce (stats-failed-tests (stats-context *stats*)) 'list)
                                  :pending (coerce (stats-pending-tests (stats-context *stats*)) 'list))))

--- a/core/stats.lisp
+++ b/core/stats.lisp
@@ -21,6 +21,7 @@
            #:suite-finish
            #:system-tests-begin
            #:system-tests-finish
+           #:summarize
            #:toplevel-stats-p
            #:all-failed-assertions))
 (in-package #:rove/core/stats)
@@ -137,16 +138,23 @@
 
 (defgeneric suite-begin (stats suite-name)
   (:method (stats suite-name)
-    (values)))
+    (declare (ignore stats suite-name))))
 
 (defgeneric suite-finish (stats suite-name)
-  (:method (stats suite-name)))
+  (:method (stats suite-name)
+    (declare (ignore stats suite-name))))
 
 (defgeneric system-tests-begin (stats system)
-  (:method (stats system)))
+  (:method (stats system)
+    (declare (ignore stats system))))
 
 (defgeneric system-tests-finish (stats system)
-  (:method (stats system)))
+  (:method (stats system)
+    (declare (ignore stats system))))
+
+(defgeneric summarize (stats)
+  (:method (stats)
+    (declare (ignore stats))))
 
 (defun toplevel-stats-p (stats)
   (null (slot-value stats 'contexts)))

--- a/core/stats.lisp
+++ b/core/stats.lisp
@@ -18,6 +18,7 @@
            #:suite-finish
            #:system-tests-begin
            #:system-tests-finish
+           #:initialize
            #:summarize
            #:toplevel-stats-p
            #:all-failed-assertions))
@@ -157,6 +158,16 @@
 (defgeneric system-tests-finish (stats system)
   (:method (stats system)
     (declare (ignore stats system))))
+
+(defgeneric initialize (stats)
+  (:method (stats)
+    (declare (ignore stats)))
+  (:method :before (stats)
+    (with-slots (passed failed pending plan) stats
+      (setf passed (make-array 0 :adjustable t :fill-pointer 0)
+            failed (make-array 0 :adjustable t :fill-pointer 0)
+            pending (make-array 0 :adjustable t :fill-pointer 0)
+            plan nil))))
 
 (defgeneric summarize (stats)
   (:method (stats)

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -70,14 +70,5 @@
       (system-tests-finish *stats* system)
       (summarize *stats*)
 
-      (let ((test (if (passedp *stats*)
-                      (first (passed-tests *stats*))
-                      (first (failed-tests *stats*)))))
-        (let ((passed (passed-tests test))
-              (failed (failed-tests test)))
-
-          (setf *last-suite-report*
-                (list (= 0 (length failed))
-                      passed
-                      failed))
-          (apply #'values *last-suite-report*))))))
+      (setf *last-suite-report* *stats*)
+      (values (passedp *stats*) *stats*))))

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -17,8 +17,7 @@
                 #:find-suite)
   (:import-from #:rove/core/suite/file
                 #:system-packages)
-  (:export #:run-system-tests
-           #:run-suite
+  (:export #:run-suite
            #:all-suites
            #:find-suite
            #:*last-suite-report*

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -73,8 +73,8 @@
       (let ((test (if (stats-passed-p *stats*)
                       (aref (stats-passed *stats*) 0)
                       (aref (stats-failed *stats*) 0))))
-        (let ((passed (test-passed-assertions test))
-              (failed (test-failed-assertions test)))
+        (let ((passed (passed-tests test))
+              (failed (failed-tests test)))
 
           (setf *last-suite-report*
                 (list (= 0 (length failed))

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -1,6 +1,5 @@
 (in-package #:cl-user)
-(defpackage #:rove/suite
-  (:nicknames #:rove/core/suite)
+(defpackage #:rove/core/suite
   (:use #:cl
         #:rove/core/assertion
         #:rove/core/result

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -1,5 +1,6 @@
 (in-package #:cl-user)
-(defpackage #:rove/core/suite
+(defpackage #:rove/suite
+  (:nicknames #:rove/core/suite)
   (:use #:cl
         #:rove/core/assertion
         #:rove/core/result

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -72,4 +72,4 @@
       (summarize *stats*)
 
       (setf *last-suite-report* *stats*)
-      (values (passedp *stats*) *stats*))))
+      (values (passedp *stats*) (stats-result *stats*)))))

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -46,7 +46,7 @@
       #-quicklisp (asdf:load-system (asdf:component-name system))
 
       (system-tests-begin *stats* system)
-      (with-context (context)
+      (with-context (context :name (asdf:component-name system))
         (typecase system
           (asdf:package-inferred-system
             (let* ((package-name (string-upcase (asdf:component-name system)))

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -69,5 +69,5 @@
       (system-tests-finish *stats* system)
       (summarize *stats*)
 
-      (setf *last-suite-report* *stats*)
+      (setf *last-suite-report* (stats-result *stats*))
       (values (passedp *stats*) (stats-result *stats*)))))

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -63,6 +63,7 @@
             (dolist (suite (system-suites system))
               (run-suite suite)))))
       (system-tests-finish *stats* system)
+      (summarize *stats*)
 
       (let ((test (if (stats-passed-p *stats*)
                       (aref (stats-passed *stats*) 0)

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -45,6 +45,7 @@
       #+quicklisp (ql:quickload (asdf:component-name system) :silent t)
       #-quicklisp (asdf:load-system (asdf:component-name system))
 
+      (initialize *stats*)
       (system-tests-begin *stats* system)
       (with-context (context :name (asdf:component-name system))
         (typecase system

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -5,14 +5,13 @@
         #:rove/core/result
         #:rove/core/test
         #:rove/core/stats)
-  (:import-from #:rove/core/result
-                #:test-name)
   (:import-from #:rove/core/suite/package
                 #:get-test
                 #:remove-test
                 #:system-suites
                 #:suite-name
-                #:run-suite)
+                #:run-suite
+                #:package-suite)
   (:import-from #:rove/core/suite/file
                 #:system-packages)
   (:export #:run-system-tests
@@ -51,17 +50,16 @@
               ;; Loading dependencies beforehand
               (let ((pkgs (system-packages system)))
                 (dolist (package pkgs)
-                  (when (package-tests package)
-                    (format t "~2&;; testing '~(~A~)'~%" (package-name package))
-                    (run-package-tests package))))
+                  (let ((suite (package-suite package)))
+                    (when suite
+                      (run-suite suite)))))
 
-              (when (and package
-                         (package-tests package))
-                (format t "~2&;; testing '~(~A~)'~%" (package-name package))
-                (run-package-tests package))))
+              (when package
+                (let ((suite (package-suite package)))
+                  (when suite
+                    (run-suite suite))))))
           (otherwise
             (dolist (suite (system-suites system))
-              (format t "~2&;; testing '~(~A~)'~%" (suite-name suite))
               (run-suite suite)))))
 
       (let ((test (if (/= (length (stats-failed *stats*)) 0)

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -11,11 +11,15 @@
                 #:system-suites
                 #:suite-name
                 #:run-suite
-                #:package-suite)
+                #:package-suite
+                #:all-suites
+                #:find-suite)
   (:import-from #:rove/core/suite/file
                 #:system-packages)
   (:export #:run-system-tests
            #:run-suite
+           #:all-suites
+           #:find-suite
            #:*last-suite-report*
            #:*rove-standard-output*
            #:*rove-error-output*

--- a/core/suite.lisp
+++ b/core/suite.lisp
@@ -70,9 +70,9 @@
       (system-tests-finish *stats* system)
       (summarize *stats*)
 
-      (let ((test (if (stats-passed-p *stats*)
-                      (aref (stats-passed *stats*) 0)
-                      (aref (stats-failed *stats*) 0))))
+      (let ((test (if (passedp *stats*)
+                      (first (passed-tests *stats*))
+                      (first (failed-tests *stats*)))))
         (let ((passed (passed-tests test))
               (failed (failed-tests test)))
 

--- a/core/suite/package.lisp
+++ b/core/suite/package.lisp
@@ -12,6 +12,7 @@
                 #:summarize
                 #:toplevel-stats-p)
   (:export #:all-suites
+           #:find-suite
            #:system-suites
            #:get-test
            #:set-test
@@ -59,16 +60,20 @@
       (setf (file-package pathname) package)))
   (make-suite :name (package-name package)))
 
-(defgeneric package-suite (package-designator)
+(defgeneric find-suite (package)
   (:method ((package package))
-    (or (gethash package *package-suites*)
-        (setf (gethash package *package-suites*)
-              (make-new-suite package))))
+    (values (gethash package *package-suites*)))
   (:method (package-name)
     (let ((package (find-package package-name)))
       (unless package
         (error "No package '~A' found" package-name))
-      (package-suite package))))
+      (find-suite package))))
+
+(defun package-suite (package)
+  (or (find-suite package)
+      (let ((package (find-package package)))
+        (setf (gethash package *package-suites*)
+              (make-new-suite package)))))
 
 (defun get-test (name)
   (check-type name symbol)

--- a/core/suite/package.lisp
+++ b/core/suite/package.lisp
@@ -7,9 +7,11 @@
                 #:system-packages)
   (:import-from #:rove/core/stats
                 #:*stats*
+                #:stats-result
                 #:with-context
                 #:suite-begin
                 #:suite-finish
+                #:passedp
                 #:initialize
                 #:summarize
                 #:toplevel-stats-p)
@@ -124,4 +126,5 @@
           (funcall (suite-teardown suite)))))
     (suite-finish *stats* suite-name)
     (when (toplevel-stats-p *stats*)
-      (summarize *stats*))))
+      (summarize *stats*))
+    (values (passedp *stats*) (stats-result *stats*))))

--- a/core/suite/package.lisp
+++ b/core/suite/package.lisp
@@ -9,6 +9,7 @@
                 #:*stats*
                 #:suite-begin
                 #:suite-finish
+                #:initialize
                 #:summarize
                 #:toplevel-stats-p)
   (:export #:all-suites
@@ -101,6 +102,8 @@
                   (suite suite)
                   (otherwise (package-suite suite))))
          (suite-name (suite-name suite)))
+    (when (toplevel-stats-p *stats*)
+      (initialize *stats*))
     (suite-begin *stats* suite-name)
     (unwind-protect
         (progn

--- a/core/suite/package.lisp
+++ b/core/suite/package.lisp
@@ -8,6 +8,7 @@
   (:import-from #:rove/core/stats
                 #:*stats*
                 #:stats-result
+                #:stats-context
                 #:with-context
                 #:suite-begin
                 #:suite-finish
@@ -127,4 +128,4 @@
     (suite-finish *stats* suite-name)
     (when (toplevel-stats-p *stats*)
       (summarize *stats*))
-    (values (passedp *stats*) (stats-result *stats*))))
+    (values (passedp *stats*) (stats-result (stats-context *stats*)))))

--- a/core/suite/package.lisp
+++ b/core/suite/package.lisp
@@ -47,6 +47,7 @@
   teardown
   before-hooks
   after-hooks
+  package
   %tests)
 
 (defun suite-tests (suite)
@@ -60,7 +61,8 @@
     (when (and pathname
                (not (file-package pathname nil)))
       (setf (file-package pathname) package)))
-  (make-suite :name (string-downcase (package-name package))))
+  (make-suite :name (string-downcase (package-name package))
+              :package package))
 
 (defgeneric find-suite (package)
   (:method ((package package))
@@ -102,7 +104,8 @@
   (let* ((suite (typecase suite
                   (suite suite)
                   (otherwise (package-suite suite))))
-         (suite-name (suite-name suite)))
+         (suite-name (suite-name suite))
+         (*package* (suite-package suite)))
     (when (toplevel-stats-p *stats*)
       (initialize *stats*))
     (suite-begin *stats* suite-name)

--- a/core/suite/package.lisp
+++ b/core/suite/package.lisp
@@ -8,7 +8,9 @@
   (:import-from #:rove/core/stats
                 #:*stats*
                 #:suite-begin
-                #:suite-finish)
+                #:suite-finish
+                #:summarize
+                #:toplevel-stats-p)
   (:export #:all-suites
            #:system-suites
            #:get-test
@@ -107,4 +109,6 @@
               (mapc #'run-hook (reverse (suite-after-hooks suite))))))
       (when (suite-teardown suite)
         (funcall (suite-teardown suite)))
-      (suite-finish *stats* suite-name))))
+      (suite-finish *stats* suite-name)
+      (when (toplevel-stats-p *stats*)
+        (summarize *stats*)))))

--- a/core/test.lisp
+++ b/core/test.lisp
@@ -30,33 +30,37 @@
                  ,(if (eq compile-at :run-time)
                     `(lambda ()
                        (funcall (compile nil '(lambda ()
-                                                (testing ,test-name
+                                                (testing (,test-name :name ,name)
                                                          ,@body)))))
                     `(lambda ()
-                       (testing ,test-name ,@body)))))))
+                       (testing (,test-name :name ,name) ,@body)))))))
 
-(defmacro testing (desc &body body)
-  (let ((main (gensym "MAIN")))
-    `(progn
-       (test-begin *stats* ,desc)
-       (with-context (context :name ,desc)
-         (flet ((,main () ,@body))
-           (if *debug-on-error*
-               (,main)
-               (block nil
-                 (handler-bind ((error
-                                  (lambda (e)
-                                    (record *stats*
-                                            (make-instance 'failed-assertion
-                                                           :form t
-                                                           :reason e
-                                                           :stacks (dissect:stack)
-                                                           :labels (and *stats*
-                                                                        (stats-context-labels *stats*))
-                                                           :desc "Raise an error while testing."))
-                                    (return nil))))
-                   (,main))))))
-       (test-finish *stats* ,desc))))
+(defmacro testing (desc-and-options &body body)
+  (destructuring-bind (desc &key name)
+      (if (consp desc-and-options)
+          desc-and-options
+          (list desc-and-options))
+    (let ((main (gensym "MAIN")))
+      `(progn
+         (test-begin *stats* ,desc)
+         (with-context (context :name ,name :description ,desc)
+           (flet ((,main () ,@body))
+             (if *debug-on-error*
+                 (,main)
+                 (block nil
+                   (handler-bind ((error
+                                    (lambda (e)
+                                      (record *stats*
+                                              (make-instance 'failed-assertion
+                                                             :form t
+                                                             :reason e
+                                                             :stacks (dissect:stack)
+                                                             :labels (and *stats*
+                                                                          (stats-context-labels *stats*))
+                                                             :desc "Raise an error while testing."))
+                                      (return nil))))
+                     (,main))))))
+         (test-finish *stats* ,desc)))))
 
 (defmacro setup (&body body)
   `(progn

--- a/core/test.lisp
+++ b/core/test.lisp
@@ -41,24 +41,24 @@
   (let ((main (gensym "MAIN")))
     `(progn
        (test-begin *stats* ,desc)
-       (unwind-protect
-            (flet ((,main () ,@body))
-              (if *debug-on-error*
-                  (,main)
-                  (block nil
-                    (handler-bind ((error
-                                     (lambda (e)
-                                       (record *stats*
-                                               (make-instance 'failed-assertion
-                                                              :form t
-                                                              :reason e
-                                                              :stacks (dissect:stack)
-                                                              :labels (and *stats*
-                                                                           (stats-context-labels *stats*))
-                                                              :desc "Raise an error while testing."))
-                                       (return nil))))
-                      (,main)))))
-         (test-finish *stats* ,desc)))))
+       (with-context (context :name ,desc)
+         (flet ((,main () ,@body))
+           (if *debug-on-error*
+               (,main)
+               (block nil
+                 (handler-bind ((error
+                                  (lambda (e)
+                                    (record *stats*
+                                            (make-instance 'failed-assertion
+                                                           :form t
+                                                           :reason e
+                                                           :stacks (dissect:stack)
+                                                           :labels (and *stats*
+                                                                        (stats-context-labels *stats*))
+                                                           :desc "Raise an error while testing."))
+                                    (return nil))))
+                   (,main))))))
+       (test-finish *stats* ,desc))))
 
 (defmacro setup (&body body)
   `(progn

--- a/core/test.lisp
+++ b/core/test.lisp
@@ -15,7 +15,6 @@
            #:defhook
            #:package-tests
            #:run-test
-           #:run-package-tests
            #:*default-test-compilation-time*))
 (in-package #:rove/core/test)
 
@@ -97,12 +96,3 @@
 
 (defun package-tests (package)
   (suite-tests (package-suite package)))
-
-(defun run-package-tests (package)
-  (check-type package package)
-  (let ((test-name (string-downcase (package-name package)))
-        (suite (package-suite package))
-        (*package* package))
-    (test-begin *stats* test-name (length (suite-tests suite)))
-    (unwind-protect (run-suite suite)
-      (test-finish *stats* test-name))))

--- a/core/test.lisp
+++ b/core/test.lisp
@@ -13,8 +13,6 @@
            #:setup
            #:teardown
            #:defhook
-           #:package-tests
-           #:run-test
            #:*default-test-compilation-time*))
 (in-package #:rove/core/test)
 
@@ -93,6 +91,3 @@
                         (:before `(suite-before-hooks (package-suite *package*)))
                         (:after `(suite-after-hooks (package-suite *package*)))))))
          (values)))))
-
-(defun package-tests (package)
-  (suite-tests (package-suite package)))

--- a/main.lisp
+++ b/main.lisp
@@ -6,6 +6,8 @@
                 #:*debug-on-error*
                 #:ok
                 #:ng
+                #:assert-ok
+                #:assert-ng
                 #:signals
                 #:outputs
                 #:expands
@@ -43,6 +45,8 @@
   (:export #:*debug-on-error*
            #:ok
            #:ng
+           #:assert-ok
+           #:assert-ng
            #:signals
            #:outputs
            #:expands

--- a/main.lisp
+++ b/main.lisp
@@ -1,80 +1,28 @@
-(in-package #:cl-user)
-(defpackage #:rove/main
-  (:nicknames #:rove)
+(uiop:define-package #:rove
+  (:nicknames #:rove/main)
   (:use #:cl)
-  (:import-from #:rove/core/assertion
-                #:*debug-on-error*
-                #:ok
-                #:ng
-                #:assert-ok
-                #:assert-ng
-                #:signals
-                #:outputs
-                #:expands
-                #:pass
-                #:fail
-                #:skip)
-  (:import-from #:rove/core/test
-                #:deftest
-                #:testing
-                #:setup
-                #:teardown
-                #:defhook
-                #:*default-test-compilation-time*)
+  (:use-reexport #:rove/core/assertion)
+  (:use-reexport #:rove/core/test)
+  (:use-reexport #:rove/core/suite)
+  (:use-reexport #:rove/core/result)
+  (:use-reexport #:rove/reporter)
   (:import-from #:rove/core/suite
-                #:run-system-tests
-                #:run-suite
-                #:get-test
-                #:remove-test)
+                #:run-system-tests)
   (:import-from #:rove/core/stats
-                #:*stats*
                 #:plan)
-  (:import-from #:rove/core/result
-                #:form-description)
-  (:import-from #:rove/reporter
-                #:use-reporter
-                #:with-reporter
-                #:diag
-                #:*report-stream*)
   (:import-from #:rove/misc/color
                 #:*enable-colors*)
   (:import-from #:rove/reporter/spec
                 #:spec-reporter)
   (:import-from #:rove/reporter/dot)
   (:import-from #:uiop)
-  (:export #:*debug-on-error*
-           #:ok
-           #:ng
-           #:assert-ok
-           #:assert-ng
-           #:signals
-           #:outputs
-           #:expands
-           #:pass
-           #:fail
-           #:skip
-           #:deftest
-           #:testing
-           #:setup
-           #:teardown
-           #:defhook
+  (:export #:run
            #:run-test
-           #:run-suite
-           #:run
-           #:remove-test
            #:with-local-envs
            #:*default-reporter*
            #:*default-env*
 
-           #:form-description
-
-           #:*stats*
            #:plan
-
-           #:diag
-           #:with-reporter
-           #:use-reporter
-           #:*report-stream*
            #:*enable-colors*))
 (in-package #:rove/main)
 

--- a/misc/color.lisp
+++ b/misc/color.lisp
@@ -3,7 +3,8 @@
   (:use #:cl)
   (:import-from #:uiop
                 #:getenv)
-  (:export #:color-text))
+  (:export #:color-text
+           #:*enable-colors*))
 (in-package #:rove/misc/color)
 
 (defvar *enable-colors*

--- a/reporter.lisp
+++ b/reporter.lisp
@@ -9,7 +9,7 @@
   (:import-from #:bordeaux-threads)
   (:export #:reporter
            #:reporter-stream
-           #:print-message
+           #:*report-stream*
            #:diag
            #:with-reporter
            #:invoke-reporter

--- a/reporter/dot.lisp
+++ b/reporter/dot.lisp
@@ -30,7 +30,7 @@
 
 (defmethod test-finish ((reporter dot-reporter) test-name)
   (declare (ignore test-name))
-  (multiple-value-bind (passedp context) (call-next-method)
+  (let ((context (stats-context reporter)))
     (when (toplevel-stats-p reporter)
       (format-failure-tests (reporter-stream reporter) context))
-    passedp))
+    (stats-passed-p context)))

--- a/reporter/dot.lisp
+++ b/reporter/dot.lisp
@@ -33,4 +33,4 @@
   (let ((context (stats-context reporter)))
     (when (toplevel-stats-p reporter)
       (format-failure-tests (reporter-stream reporter) context))
-    (stats-passed-p context)))
+    (passedp context)))

--- a/reporter/dot.lisp
+++ b/reporter/dot.lisp
@@ -31,6 +31,9 @@
 (defmethod test-finish ((reporter dot-reporter) test-name)
   (declare (ignore test-name))
   (let ((context (stats-context reporter)))
-    (when (toplevel-stats-p reporter)
-      (format-failure-tests (reporter-stream reporter) context))
     (passedp context)))
+
+(defmethod summarize ((reporter dot-reporter))
+  (when (toplevel-stats-p reporter)
+    (let ((test (stats-result reporter)))
+      (format-failure-tests (reporter-stream reporter) test))))

--- a/reporter/dot.lisp
+++ b/reporter/dot.lisp
@@ -28,8 +28,8 @@
   (let ((stream (reporter-stream reporter)))
     (princ (color-text :aqua ".") stream)))
 
-(defmethod test-finish ((reporter dot-reporter) test-name)
-  (declare (ignore test-name))
+(defmethod test-finish ((reporter dot-reporter) description)
+  (declare (ignore description))
   (let ((context (stats-context reporter)))
     (passedp context)))
 

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -97,10 +97,8 @@
 
 (defmethod summarize ((reporter spec-reporter))
   (let ((stream (reporter-stream reporter)))
-    (format-failure-tests stream (stats-context reporter))
-    (let ((test (if (/= (length (failed-tests reporter)) 0)
-                    (first (failed-tests reporter))
-                    (first (passed-tests reporter)))))
+    (let ((test (stats-result reporter)))
+      (format-failure-tests stream test)
       (let ((passed (passed-tests test))
             (failed (failed-tests test)))
 

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -92,3 +92,6 @@
          stream)
         (fresh-line stream))
       passedp)))
+
+(defmethod suite-begin ((reporter spec-reporter) suite-name)
+  (format t "~2&;; testing '~(~A~)'~%" suite-name))

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -77,10 +77,7 @@
   (let* ((context (stats-context reporter))
          (stream (reporter-stream reporter))
          (test-count (context-test-count context)))
-    (when test-name
-      (decf (stream-indent-level stream) 2))
-    (when (toplevel-stats-p reporter)
-      (format-failure-tests stream context))
+    (decf (stream-indent-level stream) 2)
     (when (and (stats-plan context)
                (/= (stats-plan context) test-count))
       (princ
@@ -98,10 +95,9 @@
 (defmethod system-tests-begin ((reporter spec-reporter) system)
   (format (reporter-stream reporter) "~2&Testing System ~A~%" (asdf:component-name system)))
 
-(defmethod system-tests-finish ((reporter spec-reporter) system)
+(defmethod summarize ((reporter spec-reporter))
   (let ((stream (reporter-stream reporter)))
-    (when (toplevel-stats-p reporter)
-      (format-failure-tests stream (stats-context reporter)))
+    (format-failure-tests stream (stats-context reporter))
     (let ((test (if (/= (length (stats-failed *stats*)) 0)
                     (aref (stats-failed *stats*) 0)
                     (aref (stats-passed *stats*) 0))))

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -64,16 +64,17 @@
       (princ (color-text :aqua (assertion-description object)) stream)
       (fresh-line stream))))
 
-(defmethod test-begin ((reporter spec-reporter) test-name &optional count)
+(defmethod test-begin ((reporter spec-reporter) description &optional count)
   (declare (ignore count))
   (let ((stream (reporter-stream reporter)))
     (fresh-line stream)
-    (when test-name
-      (princ (color-text :white test-name) stream)
+    (when description
+      (princ (color-text :white description) stream)
       (fresh-line stream)
       (incf (stream-indent-level stream) 2))))
 
-(defmethod test-finish ((reporter spec-reporter) test-name)
+(defmethod test-finish ((reporter spec-reporter) description)
+  (declare (ignore description))
   (let* ((context (stats-context reporter))
          (stream (reporter-stream reporter))
          (test-count (context-test-count context)))
@@ -106,6 +107,6 @@
         (if failed
             (format stream "  ~D test~:*~P failed.~{~%    - ~A~}~%"
                     (length failed)
-                    (mapcar #'test-name failed))
+                    (mapcar #'test-description failed))
             (format stream "  All ~D test~:*~P passed.~%"
                     (length passed)))))))

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -98,16 +98,13 @@
 (defmethod summarize ((reporter spec-reporter))
   (let ((stream (reporter-stream reporter)))
     (format-failure-tests stream (stats-context reporter))
-    (let ((test (if (/= (length (failed-tests *stats*)) 0)
-                    (first (failed-tests *stats*))
-                    (first (passed-tests *stats*)))))
-      (let ((passed (passed-tests test))
-            (failed (failed-tests test)))
+    (let ((passed (passed-tests reporter))
+          (failed (failed-tests reporter)))
 
-        (format stream "~2&Summary:~%")
-        (if failed
-            (format stream "  ~D test~:*~P failed.~{~%    - ~A~}~%"
-                    (length failed)
-                    (mapcar #'test-name failed))
-            (format stream "  All ~D test~:*~P passed.~%"
-                    (length passed)))))))
+      (format stream "~2&Summary:~%")
+      (if failed
+          (format stream "  ~D test~:*~P failed.~{~%    - ~A~}~%"
+                  (length failed)
+                  (mapcar #'test-name failed))
+          (format stream "  All ~D test~:*~P passed.~%"
+                  (length passed))))))

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -87,7 +87,7 @@
                             test-count))
         stream)
       (fresh-line stream))
-    (stats-passed-p context)))
+    (passedp context)))
 
 (defmethod suite-begin ((reporter spec-reporter) suite-name)
   (format (reporter-stream reporter) "~2&;; testing '~(~A~)'~%" suite-name))
@@ -98,9 +98,9 @@
 (defmethod summarize ((reporter spec-reporter))
   (let ((stream (reporter-stream reporter)))
     (format-failure-tests stream (stats-context reporter))
-    (let ((test (if (/= (length (stats-failed *stats*)) 0)
-                    (aref (stats-failed *stats*) 0)
-                    (aref (stats-passed *stats*) 0))))
+    (let ((test (if (/= (length (failed-tests *stats*)) 0)
+                    (first (failed-tests *stats*))
+                    (first (passed-tests *stats*)))))
       (let ((passed (passed-tests test))
             (failed (failed-tests test)))
 

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -98,13 +98,16 @@
 (defmethod summarize ((reporter spec-reporter))
   (let ((stream (reporter-stream reporter)))
     (format-failure-tests stream (stats-context reporter))
-    (let ((passed (passed-tests reporter))
-          (failed (failed-tests reporter)))
+    (let ((test (if (/= (length (failed-tests reporter)) 0)
+                    (first (failed-tests reporter))
+                    (first (passed-tests reporter)))))
+      (let ((passed (passed-tests test))
+            (failed (failed-tests test)))
 
-      (format stream "~2&Summary:~%")
-      (if failed
-          (format stream "  ~D test~:*~P failed.~{~%    - ~A~}~%"
-                  (length failed)
-                  (mapcar #'test-name failed))
-          (format stream "  All ~D test~:*~P passed.~%"
-                  (length passed))))))
+        (format stream "~2&Summary:~%")
+        (if failed
+            (format stream "  ~D test~:*~P failed.~{~%    - ~A~}~%"
+                    (length failed)
+                    (mapcar #'test-name failed))
+            (format stream "  All ~D test~:*~P passed.~%"
+                    (length passed)))))))

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -101,8 +101,8 @@
     (let ((test (if (/= (length (stats-failed *stats*)) 0)
                     (aref (stats-failed *stats*) 0)
                     (aref (stats-passed *stats*) 0))))
-      (let ((passed (test-passed-assertions test))
-            (failed (test-failed-assertions test)))
+      (let ((passed (passed-tests test))
+            (failed (failed-tests test)))
 
         (format stream "~2&Summary:~%")
         (if failed

--- a/utils/reporter.lisp
+++ b/utils/reporter.lisp
@@ -8,22 +8,24 @@
   (:export #:format-failure-tests))
 (in-package #:rove/utils/reporter)
 
-(defun format-failure-tests (stream context)
+(defun format-failure-tests (stream test)
   (fresh-line stream)
   (write-char #\Newline stream)
   (let ((stream (make-indent-stream stream)))
-    (let ((test-count (context-test-count context)))
-      (if (= 0 (length (failed-tests context)))
+    (let ((test-count (+ (length (passed-tests test))
+                         (length (failed-tests test))
+                         (length (pending-tests test)))))
+      (if (= 0 (length (failed-tests test)))
           (princ
            (color-text :green
                        (format nil "✓ ~D test~:*~P completed"
-                               (length (passed-tests context))))
+                               (length (passed-tests test))))
            stream)
           (progn
             (princ
              (color-text :red
                          (format nil "× ~D of ~D test~:*~P failed"
-                                 (length (failed-tests context))
+                                 (length (failed-tests test))
                                  test-count))
              stream)
             (let ((failed-tests
@@ -34,7 +36,7 @@
                                   (apply #'append
                                          (mapcar #'assertions
                                                  (failed-tests object)))))))
-                      (loop for object in (failed-tests context)
+                      (loop for object in (failed-tests test)
                             append (assertions object)))))
               (let ((*print-circle* t)
                     (*print-assertion* t))
@@ -88,10 +90,10 @@
                                         do (princ (color-text :gray (dissect:present-object stack nil)) stream)
                                            (fresh-line stream))))))))))))))
   (fresh-line stream)
-  (unless (= 0 (length (pending-tests context)))
+  (unless (= 0 (length (pending-tests test)))
     (princ
      (color-text :aqua
                  (format nil "● ~D test~:*~P skipped"
-                         (length (pending-tests context))))
+                         (length (pending-tests test))))
      stream)
     (fresh-line stream)))

--- a/utils/reporter.lisp
+++ b/utils/reporter.lisp
@@ -26,20 +26,20 @@
                                  (length (stats-failed context))
                                  test-count))
              stream)
-            (let ((failed-assertions
+            (let ((failed-tests
                     (labels ((assertions (object)
                                (typecase object
                                  (failed-assertion (list object))
                                  (failed-test
                                   (apply #'append
                                          (mapcar #'assertions
-                                                 (test-failed-assertions object)))))))
+                                                 (failed-tests object)))))))
                       (loop for object across (stats-failed context)
                             append (assertions object)))))
               (let ((*print-circle* t)
                     (*print-assertion* t))
                 (loop for i from 0
-                      for f in failed-assertions
+                      for f in failed-tests
                       do (fresh-line stream)
                          (write-char #\Newline stream)
                          (princ

--- a/utils/reporter.lisp
+++ b/utils/reporter.lisp
@@ -13,17 +13,17 @@
   (write-char #\Newline stream)
   (let ((stream (make-indent-stream stream)))
     (let ((test-count (context-test-count context)))
-      (if (= 0 (length (stats-failed context)))
+      (if (= 0 (length (failed-tests context)))
           (princ
            (color-text :green
                        (format nil "✓ ~D test~:*~P completed"
-                               (length (stats-passed context))))
+                               (length (passed-tests context))))
            stream)
           (progn
             (princ
              (color-text :red
                          (format nil "× ~D of ~D test~:*~P failed"
-                                 (length (stats-failed context))
+                                 (length (failed-tests context))
                                  test-count))
              stream)
             (let ((failed-tests
@@ -34,7 +34,7 @@
                                   (apply #'append
                                          (mapcar #'assertions
                                                  (failed-tests object)))))))
-                      (loop for object across (stats-failed context)
+                      (loop for object in (failed-tests context)
                             append (assertions object)))))
               (let ((*print-circle* t)
                     (*print-assertion* t))
@@ -88,10 +88,10 @@
                                         do (princ (color-text :gray (dissect:present-object stack nil)) stream)
                                            (fresh-line stream))))))))))))))
   (fresh-line stream)
-  (unless (= 0 (length (stats-pending context)))
+  (unless (= 0 (length (pending-tests context)))
     (princ
      (color-text :aqua
                  (format nil "● ~D test~:*~P skipped"
-                         (length (stats-pending context))))
+                         (length (pending-tests context))))
      stream)
     (fresh-line stream)))


### PR DESCRIPTION
- [x] Add `assert-ok` & `assert-ng` for developers hoping to make their own assertion macros
- [x] Add (or rename) accessors for test results
- [x] Add handful hooks and change "reporters" to use them
  - [x] Add `suite-begin` & `suite-finish`
  - [x] Add `system-test-begin` & `system-test-finish`
  - [x] Add `summarize` to hook the end of all tests and print the summary