### PR TITLE
Change `testing` return value

### DIFF
--- a/core/test.lisp
+++ b/core/test.lisp
@@ -18,23 +18,6 @@
 
 (defvar *default-test-compilation-time* :definition-time)
 
-(defmacro deftest (name-and-options &body body)
-  (destructuring-bind (name &key (compile-at *default-test-compilation-time*))
-      (if (consp name-and-options)
-          name-and-options
-          (list name-and-options))
-    (check-type compile-at (member :run-time :definition-time))
-    (let ((test-name (let ((*print-case* :downcase))
-                       (princ-to-string name))))
-      `(set-test ',name
-                 ,(if (eq compile-at :run-time)
-                    `(lambda ()
-                       (funcall (compile nil '(lambda ()
-                                                (testing-with-options ,test-name (:name ',name)
-                                                  ,@body)))))
-                    `(lambda ()
-                       (testing-with-options ,test-name (:name ',name) ,@body)))))))
-
 (defmacro testing-with-options (desc (&key name) &body body)
   (let ((main (gensym "MAIN")))
     `(progn
@@ -57,6 +40,23 @@
                                     (return nil))))
                    (,main))))))
        (test-finish *stats* ,desc))))
+
+(defmacro deftest (name-and-options &body body)
+  (destructuring-bind (name &key (compile-at *default-test-compilation-time*))
+      (if (consp name-and-options)
+          name-and-options
+          (list name-and-options))
+    (check-type compile-at (member :run-time :definition-time))
+    (let ((test-name (let ((*print-case* :downcase))
+                       (princ-to-string name))))
+      `(set-test ',name
+                 ,(if (eq compile-at :run-time)
+                    `(lambda ()
+                       (funcall (compile nil '(lambda ()
+                                                (testing-with-options ,test-name (:name ',name)
+                                                  ,@body)))))
+                    `(lambda ()
+                       (testing-with-options ,test-name (:name ',name) ,@body)))))))
 
 (defmacro testing (desc &body body)
   `(testing-with-options ,desc () ,@body))

--- a/core/test.lisp
+++ b/core/test.lisp
@@ -18,7 +18,7 @@
 
 (defvar *default-test-compilation-time* :definition-time)
 
-(defmacro testing-with-options (desc (&key name) &body body)
+(defmacro with-testing-with-options (desc (&key name) &body body)
   (let ((main (gensym "MAIN")))
     `(progn
        (test-begin *stats* ,desc)
@@ -53,13 +53,13 @@
                  ,(if (eq compile-at :run-time)
                     `(lambda ()
                        (funcall (compile nil '(lambda ()
-                                                (testing-with-options ,test-name (:name ',name)
+                                                (with-testing-with-options ,test-name (:name ',name)
                                                   ,@body)))))
                     `(lambda ()
-                       (testing-with-options ,test-name (:name ',name) ,@body)))))))
+                       (with-testing-with-options ,test-name (:name ',name) ,@body)))))))
 
 (defmacro testing (desc &body body)
-  `(testing-with-options ,desc () ,@body))
+  `(with-testing-with-options ,desc () ,@body))
 
 (defmacro setup (&body body)
   `(progn

--- a/rove.asd
+++ b/rove.asd
@@ -4,4 +4,11 @@
   :author "Eitaro Fukamachi"
   :license "BSD 3-Clause"
   :depends-on ("rove/main")
-  :description "Yet another testing framework intended to be a successor of Prove")
+  :description "Yet another testing framework intended to be a successor of Prove"
+  :in-order-to ((test-op (test-op "rove/tests"))))
+
+(defsystem "rove/tests"
+  :class :package-inferred-system
+  :depends-on ("rove"
+               "rove/tests/main")
+  :perform (test-op (o c) (symbol-call :rove/tests/main :run-all-tests)))

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -1,0 +1,19 @@
+(defpackage :rove/tests/main
+  (:use :cl))
+(in-package :rove/tests/main)
+
+(rove:deftest example-test
+  42)
+
+(defun testing-returns-the-body-result ()
+  (let ((expected 300)
+        (actual (rove:testing "hello" 100 200 300)))
+    (assert (equal expected actual))))
+
+(defun run-test-returns-the-body-result ()
+  (let ((expected 42)
+        (actual (rove:run-test 'example-test)))
+    (assert (equal expected actual))))
+
+(defun run-all-tests ()
+  (testing-returns-the-body-result))


### PR DESCRIPTION
I often use `testing` or `run-test` return values.
At some point in time, this behavior was changed.
 Upon confirmation, this behavior was not what was intended, so a PR was created to restore the original behavior.