### PR TITLE
Add run-tests

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -20,6 +20,7 @@
   (:export #:run
            #:run*
            #:run-test
+           #:run-tests
            #:with-local-envs
            #:*default-reporter*
            #:*default-env*
@@ -63,7 +64,12 @@
   (let ((test (ensure-test test-name)))
     (with-reporter style
       (testing nil
-               (funcall test)))))
+        (funcall test)))))
+
+(defmethod run-tests (test-names &key (style :spec))
+  (let ((tests (mapcar #'ensure-test test-names)))
+    (with-reporter style
+      (run-test-functions tests))))
 
 (defmethod run (target &key (style *default-reporter*) (env *default-env*))
   (with-local-envs env

--- a/main.lisp
+++ b/main.lisp
@@ -53,10 +53,14 @@
 (defgeneric run (target &key style env)
   (:documentation "Run a test package."))
 
-(defmethod run-test (test-name &key (style :spec))
+(defun ensure-test (test-name)
   (let ((test (get-test test-name)))
     (unless test
       (error "No test found for ~S" test-name))
+    test))
+
+(defmethod run-test (test-name &key (style :spec))
+  (let ((test (ensure-test test-name)))
     (with-reporter style
       (testing nil
                (funcall test)))))


### PR DESCRIPTION
It corresponds to the first of https://github.com/fukamachi/rove/issues/58

For example, use the following

```common-lisp
(rove:run-tests '(test-1 test-2))
```

The return signature is aligned with rove:run.