### PR TITLE
Add `*quit-on-failure*` option

### DIFF
--- a/core/assertion.lisp
+++ b/core/assertion.lisp
@@ -7,6 +7,7 @@
   (:import-from #:dissect
                 #:stack)
   (:export #:*debug-on-error*
+           #:*abort-on-error*
            #:ok
            #:ng
            #:assert-ok
@@ -23,6 +24,11 @@
   (let ((debug-on-error-symbol (intern (string :*rove-debug-on-error*) :cl-user)))
     (and (boundp debug-on-error-symbol)
 	 (symbol-value debug-on-error-symbol))))
+
+(defvar *abort-on-error*
+  (let ((abort-on-error-symbol (intern (string :*rove-abort-on-error*) :cl-user)))
+    (and (boundp abort-on-error-symbol)
+         (symbol-value abort-on-error-symbol))))
 
 (defun form-steps (form)
   (if (consp form)

--- a/core/assertion.lisp
+++ b/core/assertion.lisp
@@ -7,7 +7,7 @@
   (:import-from #:dissect
                 #:stack)
   (:export #:*debug-on-error*
-           #:*abort-on-error*
+           #:*quit-on-failure*
            #:ok
            #:ng
            #:assert-ok
@@ -25,10 +25,10 @@
     (and (boundp debug-on-error-symbol)
 	 (symbol-value debug-on-error-symbol))))
 
-(defvar *abort-on-error*
-  (let ((abort-on-error-symbol (intern (string :*rove-abort-on-error*) :cl-user)))
-    (and (boundp abort-on-error-symbol)
-         (symbol-value abort-on-error-symbol))))
+(defvar *quit-on-failure*
+  (let ((quit-on-failure-symbol (intern (string :*rove-quit-on-failure*) :cl-user)))
+    (and (boundp quit-on-failure-symbol)
+         (symbol-value quit-on-failure-symbol))))
 
 (defun form-steps (form)
   (if (consp form)

--- a/core/test.lisp
+++ b/core/test.lisp
@@ -5,6 +5,7 @@
         #:rove/core/suite/package)
   (:import-from #:rove/core/assertion
                 #:*debug-on-error*
+                #:*abort-on-error*
                 #:failed-assertion)
   (:import-from #:dissect
                 #:stack)
@@ -37,7 +38,11 @@
                                                          :desc "Raise an error while testing."))
                                   (return nil))))
                  (funcall function)))))
-    (test-finish *stats* desc)))
+    (when (and *abort-on-error* (not (passedp (stats-context *stats*))))
+      (format t "Failed test, with the abort option enabled. ~%")
+      (abort))
+
+    (test-finish *stats* desc))))
 
 (defmacro with-testing-with-options (desc (&key name) &body body)
   `(call-with-testing-with-options ,desc ,name (lambda () ,@body)))

--- a/core/test.lisp
+++ b/core/test.lisp
@@ -5,7 +5,7 @@
         #:rove/core/suite/package)
   (:import-from #:rove/core/assertion
                 #:*debug-on-error*
-                #:*abort-on-error*
+                #:*quit-on-failure*
                 #:failed-assertion)
   (:import-from #:dissect
                 #:stack)
@@ -38,7 +38,7 @@
                                                          :desc "Raise an error while testing."))
                                   (return nil))))
                  (funcall function)))))
-    (when (and *abort-on-error*
+    (when (and *quit-on-failure*
                (not (passedp (stats-context *stats*))))
       (format t "Failed test, with the abort option enabled. ~%")
       (abort))

--- a/core/test.lisp
+++ b/core/test.lisp
@@ -38,11 +38,12 @@
                                                          :desc "Raise an error while testing."))
                                   (return nil))))
                  (funcall function)))))
-    (when (and *abort-on-error* (not (passedp (stats-context *stats*))))
+    (when (and *abort-on-error*
+               (not (passedp (stats-context *stats*))))
       (format t "Failed test, with the abort option enabled. ~%")
       (abort))
 
-    (test-finish *stats* desc))))
+    (test-finish *stats* desc)))
 
 (defmacro with-testing-with-options (desc (&key name) &body body)
   `(call-with-testing-with-options ,desc ,name (lambda () ,@body)))


### PR DESCRIPTION
I think sometimes there is the possibility that there is a huge testing system and that waiting to all test to finish are not that desirable. So it's easier to stop on an error and focus on that one, instead of waiting for the entire error suite to finish.

I just implemented the bare-bones option, but still think that when aborting the execution, a more detailed explanation maybe more suitable.