### PR TITLE
Summarize the inner result object if the number of tests is one.

### DIFF
--- a/reporter.lisp
+++ b/reporter.lisp
@@ -3,9 +3,14 @@
   (:use #:cl)
   (:import-from #:rove/core/stats
                 #:stats
-                #:*stats*)
+                #:*stats*
+                #:stats-results)
   (:import-from #:rove/reporter/registry
                 #:get-reporter)
+  (:import-from #:rove/core/result
+                #:passed-tests
+                #:failed-tests
+                #:pending-tests)
   (:import-from #:bordeaux-threads)
   (:export #:reporter
            #:reporter-stream
@@ -17,10 +22,29 @@
 (in-package #:rove/reporter)
 
 (defvar *report-stream* (make-synonym-stream '*standard-output*))
+(defvar *single-test-summarize-preference* t)
 
 (defclass reporter (stats)
   ((stream :initarg :stream
            :accessor reporter-stream)))
+
+(defmethod passed-tests ((reporter reporter))
+  (if (and *single-test-summarize-preference*
+           (null (rest (stats-results reporter))))
+      (passed-tests (first (stats-results reporter)))
+      (call-next-method)))
+
+(defmethod failed-tests ((reporter reporter))
+  (if (and *single-test-summarize-preference*
+           (null (rest (stats-results reporter))))
+      (failed-tests (first (stats-results reporter)))
+      (call-next-method)))
+
+(defmethod pending-tests ((reporter reporter))
+  (if (and *single-test-summarize-preference*
+           (null (rest (stats-results reporter))))
+      (pending-tests (first (stats-results reporter)))
+      (call-next-method)))
 
 (defun make-reporter (style &key (stream *report-stream*))
   (let ((class-name (get-reporter style)))

--- a/reporter/dot.lisp
+++ b/reporter/dot.lisp
@@ -34,8 +34,7 @@
     (passedp context)))
 
 (defmethod summarize ((reporter dot-reporter))
-  (when (toplevel-stats-p reporter)
-    (format-failure-tests (reporter-stream reporter)
-                          (stats-passed-tests reporter)
-                          (stats-failed-tests reporter)
-                          (stats-pending-tests reporter))))
+  (format-failure-tests (reporter-stream reporter)
+                        (passed-tests reporter)
+                        (failed-tests reporter)
+                        (pending-tests reporter)))

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -97,18 +97,16 @@
   (format (reporter-stream reporter) "~2&Testing System ~A~%" (asdf:component-name system)))
 
 (defmethod summarize ((reporter spec-reporter))
-  (let ((stream (reporter-stream reporter)))
-    (format-failure-tests stream
-                          (stats-passed-tests reporter)
-                          (stats-failed-tests reporter)
-                          (stats-pending-tests reporter))
-    (let ((passed (stats-passed-tests reporter))
-          (failed (stats-failed-tests reporter)))
+  (let ((stream (reporter-stream reporter))
+        (passed (passed-tests reporter))
+        (failed (failed-tests reporter))
+        (pending (pending-tests reporter)))
+    (format-failure-tests stream passed failed pending)
 
-      (format stream "~2&Summary:~%")
-      (if (= 0 (length failed))
-          (format stream "  All ~D test~:*~P passed.~%"
-                  (length passed))
-          (format stream "  ~D test~:*~P failed.~{~%    - ~A~}~%"
-                  (length failed)
-                  (map 'list #'test-name failed))))))
+    (format stream "~2&Summary:~%")
+    (if (= 0 (length failed))
+      (format stream "  All ~D test~:*~P passed.~%"
+              (length passed))
+      (format stream "  ~D test~:*~P failed.~{~%    - ~A~}~%"
+              (length failed)
+              (map 'list #'test-name failed)))))

--- a/utils/reporter.lisp
+++ b/utils/reporter.lisp
@@ -36,8 +36,8 @@
                                   (apply #'append
                                          (mapcar #'assertions
                                                  (failed-tests object)))))))
-                      (loop for object across failed-tests
-                            append (assertions object)))))
+                      (loop for test in failed-tests
+                            append (assertions test)))))
               (let ((*print-circle* t)
                     (*print-assertion* t))
                 (loop for i from 0


### PR DESCRIPTION
This is intended for running tests of a single system.

ref #60 