### PR TITLE
Print the source location of failed assertions.

### DIFF
--- a/core/result.lisp
+++ b/core/result.lisp
@@ -18,6 +18,7 @@
            #:assertion-stacks
            #:assertion-labels
            #:assertion-description
+           #:assertion-source-location
            #:dump-details
 
            #:test
@@ -68,7 +69,10 @@
    (desc :initarg :desc
          :initform nil)
    (negative :initarg :negative
-             :initform nil)))
+             :initform nil)
+   (source-location :initarg :source-location
+                    :initform nil
+                    :reader assertion-source-location)))
 
 (defmethod print-object ((assertion assertion) stream)
   (if *print-assertion*

--- a/core/source-location.lisp
+++ b/core/source-location.lisp
@@ -30,8 +30,8 @@
               (*sf-index* 0)
               (*target-sf-index* (1+ sf-index)))
           (read in))
-      (form-found ()))
-    (file-position in)))
+      (form-found () (file-position in))
+      (end-of-file ()))))
 
 (defun source-location ()
   #-sbcl nil

--- a/core/source-location.lisp
+++ b/core/source-location.lisp
@@ -1,0 +1,51 @@
+(defpackage #:rove/core/source-location
+  (:use #:cl)
+  (:export #:source-location
+           #:source-location-file-position))
+(in-package #:rove/core/source-location)
+
+(defvar *sf-index*)
+(defvar *target-sf-index*)
+
+(define-condition form-found () ())
+
+(defun index-read-list (stream char)
+  (incf *sf-index*)
+  (when (= *sf-index* *target-sf-index*)
+    (unread-char char stream)
+    (signal 'form-found))
+  (funcall '#.(get-macro-character #\() stream char))
+
+(defparameter *location-finder-readtable*
+  (let ((readtable (copy-readtable)))
+    (set-macro-character #\( #'index-read-list nil readtable)
+    readtable))
+
+(defun get-file-position (file tlf-index sf-index)
+  (with-open-file (in file)
+    (dotimes (i tlf-index)
+      (read in))
+    (handler-case
+        (let ((*readtable* *location-finder-readtable*)
+              (*sf-index* 0)
+              (*target-sf-index* (1+ sf-index)))
+          (read in))
+      (form-found ()))
+    (file-position in)))
+
+(defun source-location ()
+  #-sbcl nil
+  #+sbcl
+  (let ((sb-source (sb-c::make-definition-source-location)))
+    (when (and sb-source
+               (sb-c::definition-source-location-namestring sb-source))
+      (list
+       :file (sb-c:definition-source-location-namestring sb-source)
+       :tlf-index (sb-c:definition-source-location-toplevel-form-number sb-source)
+       :sf-index (sb-c:definition-source-location-form-number sb-source)))))
+
+(defun source-location-file-position (source-location)
+  (when source-location
+    (destructuring-bind (&key file tlf-index sf-index)
+        source-location
+      (list file (get-file-position file tlf-index sf-index)))))

--- a/utils/reporter.lisp
+++ b/utils/reporter.lisp
@@ -70,10 +70,10 @@
                               stream)
                              (let ((source-location (assertion-source-location f)))
                                (when source-location
-                                 (destructuring-bind (file pos)
+                                 (destructuring-bind (file line column)
                                      (source-location-file-position source-location)
-                                   (format stream "~&    at ~A~@[:~A~]~%"
-                                           file pos))))))
+                                   (format stream "~&    at ~A~@[:~A~]~@[:~A~]~%"
+                                           file line column))))))
                          (fresh-line stream)
                          (with-indent (stream (+ (length (write-to-string i)) 2))
                            (when (assertion-reason f)

--- a/utils/reporter.lisp
+++ b/utils/reporter.lisp
@@ -5,6 +5,8 @@
         #:rove/core/result
         #:rove/misc/stream
         #:rove/misc/color)
+  (:import-from #:rove/core/source-location
+                #:source-location-file-position)
   (:export #:format-failure-tests))
 (in-package #:rove/utils/reporter)
 
@@ -65,7 +67,13 @@
                              (princ
                               (color-text :white
                                           (assertion-description f))
-                              stream)))
+                              stream)
+                             (let ((source-location (assertion-source-location f)))
+                               (when source-location
+                                 (destructuring-bind (file pos)
+                                     (source-location-file-position source-location)
+                                   (format stream "~&    at ~A:~A~%"
+                                           file pos))))))
                          (fresh-line stream)
                          (with-indent (stream (+ (length (write-to-string i)) 2))
                            (when (assertion-reason f)

--- a/utils/reporter.lisp
+++ b/utils/reporter.lisp
@@ -10,6 +10,14 @@
   (:export #:format-failure-tests))
 (in-package #:rove/utils/reporter)
 
+(defun print-source-location (stream assertion)
+  (let ((source-location (assertion-source-location assertion)))
+    (when source-location
+      (destructuring-bind (file line column)
+          (source-location-file-position source-location)
+        (format stream "~&at ~A~@[:~A~]~@[:~A~]~%"
+                file line column)))))
+
 (defun format-failure-tests (stream passed-tests failed-tests pending-tests)
   (fresh-line stream)
   (write-char #\Newline stream)
@@ -68,12 +76,8 @@
                               (color-text :white
                                           (assertion-description f))
                               stream)
-                             (let ((source-location (assertion-source-location f)))
-                               (when source-location
-                                 (destructuring-bind (file line column)
-                                     (source-location-file-position source-location)
-                                   (format stream "~&    at ~A~@[:~A~]~@[:~A~]~%"
-                                           file line column))))))
+                             (with-indent (stream +4)
+                               (print-source-location stream f))))
                          (fresh-line stream)
                          (with-indent (stream (+ (length (write-to-string i)) 2))
                            (when (assertion-reason f)

--- a/utils/reporter.lisp
+++ b/utils/reporter.lisp
@@ -72,7 +72,7 @@
                                (when source-location
                                  (destructuring-bind (file pos)
                                      (source-location-file-position source-location)
-                                   (format stream "~&    at ~A:~A~%"
+                                   (format stream "~&    at ~A~@[:~A~]~%"
                                            file pos))))))
                          (fresh-line stream)
                          (with-indent (stream (+ (length (write-to-string i)) 2))


### PR DESCRIPTION
Print the source file and its file position of failed assertion. It's available only for SBCL.

<img width="874" alt="Screenshot 2023-09-06 at 11 34 19" src="https://github.com/fukamachi/rove/assets/90570/a9167003-2d5b-4791-8b2e-505e17304406">
