### PR TITLE
Use desc for context name if name is nil

### DIFF
--- a/core/test.lisp
+++ b/core/test.lisp
@@ -21,7 +21,7 @@
 (defun call-with-testing-with-options (desc name function)
   (test-begin *stats* desc)
   (unwind-protect
-       (with-context (context :name name :description desc)
+       (with-context (context :name (or name desc) :description desc)
          (if *debug-on-error*
              (funcall function)
              (block nil


### PR DESCRIPTION
testing's desc is not displayed.

```lisp
CL-USER> (ql:quickload :rove)
To load "rove":
  Load 1 ASDF system:
    rove
; Loading "rove"
[package rove/core/test]..........................
[package rove/core/suite]....
(:ROVE)
CL-USER> (rove:deftest alfa
           (rove:testing "bravo"
             (rove:ng t)))
CL-USER> (rove:run-suite 'cl-user)

;; testing 'common-lisp-user'
alfa
  bravo
    × 0) Expect T to be false.

× 1 of 1 test failed

0) ALFA
     › NIL

   Expect T to be false.
     T

Summary:
  1 test failed.
    - common-lisp-user
NIL
(#<ROVE/CORE/RESULT:FAILED-TEST common-lisp-user (PASSED=0, FAILED=1)> #<ROVE/CORE/RESULT:FAILED-TEST common-lisp-user (PASSED=0, FAILED=1)>)
```

After bugfix.

```lisp
CL-USER> (rove:run-suite 'cl-user)

;; testing 'common-lisp-user'
alfa
  bravo
    × 0) Expect T to be false.

× 1 of 1 test failed

0) ALFA
     › bravo

   Expect T to be false.
     T

Summary:
  1 test failed.
    - ALFA
NIL
(#<ROVE/CORE/RESULT:FAILED-TEST common-lisp-user (PASSED=0, FAILED=1)>)
```