### PR TITLE
Add `failing` macro that expects all assertions within the body to fail.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -137,6 +137,24 @@ $ ros install rove
     (ok (= (length (list 1 2 3)) 3))))
 ```
 
+### failing (description &body body)
+
+Expects all assertions within the body to fail. If any assertion passes, the test fails and reports which assertions unexpectedly passed. This is useful for testing code that is known to be broken or not yet implemented.
+
+```common-lisp
+(deftest incomplete-feature
+  (failing "TODO: implement addition"
+    (ok (= (add 1 2) 3))
+    (ok (= (add 5 5) 10))))
+;-> ✓ Expect (= (ADD 1 2) 3) to be true.
+;-> ✓ Expect (= (ADD 5 5) 10) to be true.
+;
+; Summary shows:
+; 0) INCOMPLETE-FEATURE
+;      › TODO: implement addition
+;    Expected to fail: Expect (= (ADD 1 2) 3) to be true.
+```
+
 ### setup (&body body)
 
 Evaluates before testing the package once. This would be useful for initialization of tests, like establishment to the DB or creating a temporary directory.

--- a/core/result.lisp
+++ b/core/result.lisp
@@ -8,6 +8,7 @@
            #:form-description
 
            #:*print-assertion*
+           #:*suppress-assertion-printing*
            #:assertion
            #:assertion-form
            #:assertion-steps
@@ -37,6 +38,7 @@
 (in-package #:rove/core/result)
 
 (defvar *print-assertion* nil)
+(defvar *suppress-assertion-printing* nil)
 
 (defclass passed () ())
 (defclass failed () ())

--- a/core/test.lisp
+++ b/core/test.lisp
@@ -8,10 +8,15 @@
                 #:*quit-on-failure*
                 #:failed-assertion
                 #:quit-early)
+  (:import-from #:rove/core/result
+                #:passed-assertion
+                #:assertion-description
+                #:*suppress-assertion-printing*)
   (:import-from #:dissect
                 #:stack)
   (:export #:deftest
            #:testing
+           #:failing
            #:setup
            #:teardown
            #:defhook
@@ -67,6 +72,36 @@
 
 (defmacro testing (desc &body body)
   `(with-testing-with-options ,desc () ,@body))
+
+(defmacro failing (desc &body body)
+  "Execute BODY expecting all assertions to fail. If any assertion passes,
+   the failing block itself is marked as failed."
+  (let ((context (gensym "CONTEXT"))
+        (unexpected-passes (gensym "UNEXPECTED-PASSES")))
+    `(progn
+       (test-begin *stats* ,desc)
+       (unwind-protect
+            (with-context (,context :name ,desc :description ,desc)
+              ,@body
+              ;; Collect unexpected passes
+              (let ((,unexpected-passes (coerce (stats-passed-tests ,context) 'list)))
+                ;; Clear the context stats - we'll handle reporting differently
+                (setf (slot-value ,context 'rove/core/stats::passed)
+                      (make-array 0 :adjustable t :fill-pointer 0))
+                (setf (slot-value ,context 'rove/core/stats::failed)
+                      (make-array 0 :adjustable t :fill-pointer 0))
+                ;; Change unexpected passes to failures and record them
+                (let ((*suppress-assertion-printing* t))
+                  (dolist (assertion ,unexpected-passes)
+                    ;; Change class from passed-assertion to failed-assertion
+                    (change-class assertion 'failed-assertion)
+                    ;; Update description
+                    (setf (slot-value assertion 'rove/core/result::desc)
+                          (format nil "Expected to fail: ~A"
+                                  (assertion-description assertion)))
+                    ;; Record in parent context as a failure
+                    (record *stats* assertion)))))
+         (test-finish *stats* ,desc)))))
 
 (defmacro setup (&body body)
   `(progn

--- a/reporter/spec.lisp
+++ b/reporter/spec.lisp
@@ -32,28 +32,30 @@
 
 (defmethod record ((reporter spec-reporter) (object passed-assertion))
   (call-next-method)
-  (let ((stream (reporter-stream reporter)))
-    (fresh-line stream)
-    (princ (color-text :green "✓ ") stream)
-    (with-indent (stream +2)
-      (princ (color-text :gray (assertion-description object)) stream)
-      (print-duration (assertion-duration object) stream)
-      (fresh-line stream))))
+  (unless *suppress-assertion-printing*
+    (let ((stream (reporter-stream reporter)))
+      (fresh-line stream)
+      (princ (color-text :green "✓ ") stream)
+      (with-indent (stream +2)
+        (princ (color-text :gray (assertion-description object)) stream)
+        (print-duration (assertion-duration object) stream)
+        (fresh-line stream)))))
 
 (defmethod record ((reporter spec-reporter) (object failed-assertion))
   (call-next-method)
-  (let ((stream (reporter-stream reporter)))
-    (fresh-line stream)
-    (princ (color-text :red "× ") stream)
-    (with-indent (stream +2)
-      (princ
-       (color-text :red
-                   (format nil "~D) ~A"
-                           (1- (length (all-failed-assertions *stats*)))
-                           (assertion-description object)))
-       stream)
-      (print-duration (assertion-duration object) stream)
-      (fresh-line stream))))
+  (unless *suppress-assertion-printing*
+    (let ((stream (reporter-stream reporter)))
+      (fresh-line stream)
+      (princ (color-text :red "× ") stream)
+      (with-indent (stream +2)
+        (princ
+         (color-text :red
+                     (format nil "~D) ~A"
+                             (1- (length (all-failed-assertions *stats*)))
+                             (assertion-description object)))
+         stream)
+        (print-duration (assertion-duration object) stream)
+        (fresh-line stream)))))
 
 (defmethod record ((reporter spec-reporter) (object pending-assertion))
   (call-next-method)

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -15,5 +15,27 @@
         (actual (rove:run-test 'example-test)))
     (assert (equal expected actual))))
 
+(rove:deftest test-failing-with-all-failures
+  (rove:testing "failing block where all assertions fail (should pass)"
+    (rove:failing "TODO: implement feature X"
+      (rove:ok (= 1 0))
+      (rove:ok (char= #\a #\b)))))
+
+(rove:deftest test-failing-with-unexpected-success
+  (rove:testing "failing block where assertions pass (should fail)"
+    (rove:failing "This should fail but doesn't"
+      (rove:ok (= 1 1)))))
+
+(rove:deftest test-failing-with-mixed-results
+  (rove:testing "failing block with mixed results (should fail because some pass)"
+    (rove:failing "Mixed results"
+      (rove:ok (= 1 1))
+      (rove:ok (= 1 0)))))
+
+(rove:deftest test-failing-with-no-assertions
+  (rove:testing "failing block with no assertions (should fail)"
+    (rove:failing "Empty block"
+      nil)))
+
 (defun run-all-tests ()
   (testing-returns-the-body-result))


### PR DESCRIPTION
`failing` is similar to `testing` in terms of containing multiple assertions, but if any assertion passes, the test fails and reports which assertions unexpectedly passed. This is useful for testing code that is known to be broken or not yet implemented.

```common-lisp
(deftest incomplete-feature
  (failing "TODO: implement addition"
    (ok (= (add 1 2) 3))
    (ok (= (add 5 5) 10))))
;-> ✓ Expect (= (ADD 1 2) 3) to be true.
;-> ✓ Expect (= (ADD 5 5) 10) to be true.
;
; Summary shows:
; 0) INCOMPLETE-FEATURE
;      › TODO: implement addition
;    Expected to fail: Expect (= (ADD 1 2) 3) to be true.
```