### PR TITLE
Fix FASL path resolution when ASDF_OUTPUT_TRANSLATIONS is set

### DIFF
--- a/core/suite/file.lisp
+++ b/core/suite/file.lisp
@@ -102,11 +102,15 @@ translations may be reconfigured during an interactive session."
                      :directory (cons :absolute directories))
                     (uiop:lispize-pathname pathname)))
               (progn
-                (warn "resolve-file: could not map FASL ~A back to its source file. ~
-                       ASDF_OUTPUT_TRANSLATIONS may point to a location that rove's ~
-                       cache-root probe did not detect.  Run with a uniform single-rule ~
-                       output translation or ensure *user-cache* is set."
-                      pathname)
+                ;; Rate-limit: warn once per session so a misconfigured
+                ;; translation does not flood output with one message per file.
+                (unless *translation-probe-warned*
+                  (setf *translation-probe-warned* t)
+                  (warn "resolve-file: could not map FASL ~A back to its source file. ~
+                         ASDF_OUTPUT_TRANSLATIONS may point to a location that rove's ~
+                         cache-root probe did not detect.  Run with a uniform single-rule ~
+                         output translation or ensure *user-cache* is set."
+                        pathname))
                 (uiop:lispize-pathname pathname))))))))
 
 

--- a/core/suite/file.lisp
+++ b/core/suite/file.lisp
@@ -15,6 +15,37 @@
        (<= 2 (length impl))
        (string= impl "-s" :start1 (- (length impl) 2))))
 
+;; Cached result of computing the ASDF output translation root.
+;; :not-computed means the value has not been determined yet.
+(defvar *effective-fasl-cache-root* :not-computed)
+
+(defun effective-fasl-cache-root ()
+  "Return the root directory under which ASDF stores compiled files
+according to the current output translation configuration.
+When ASDF_OUTPUT_TRANSLATIONS points to a custom cache, this returns that
+custom root rather than the default asdf:*user-cache*.
+Returns nil if the translation appears to be an identity (no separate cache).
+
+The probe pathname is intentionally one directory component deep so that
+butlast peeling exactly (length source-comps) components isolates the prefix.
+This assumes a single uniform translation rule applies to all source files."
+  (when (eq *effective-fasl-cache-root* :not-computed)
+    (setf *effective-fasl-cache-root*
+          (handler-case
+              (let* ((probe (make-pathname :directory '(:absolute "rove--fasl-probe")
+                                           :name "probe" :type "lisp"))
+                     (translated (asdf:apply-output-translations probe))
+                     (source-comps (cdr (pathname-directory probe)))
+                     (trans-comps (cdr (pathname-directory translated)))
+                     (cache-comps (butlast trans-comps (length source-comps))))
+                (when (and cache-comps (every #'stringp cache-comps))
+                  (make-pathname :directory (cons :absolute cache-comps)
+                                 :name nil :type nil :version nil
+                                 :defaults translated)))
+            (error ()
+              nil))))
+  *effective-fasl-cache-root*)
+
 (defun resolve-file (pathname)
   (block nil
     (unless pathname
@@ -22,32 +53,52 @@
     (let ((pathname (uiop:ensure-absolute-pathname pathname)))
       (unless (compile-file-p pathname)
         (return pathname))
-      (unless asdf:*user-cache*
-        (return pathname))
-      (if (or (eql (search (namestring asdf:*user-cache*)
-                           (namestring pathname))
-                   0)
-              (let ((impl (uiop:implementation-identifier)))
-                (and (uiop:featurep :sb-thread)
-                     (multithread-suffix-p impl)
-                     (eql (search (namestring
-                                   (merge-pathnames
-                                    ;; UIOP may add -s suffix for multithreaded SBCL.
-                                    (subseq impl 0 (- (length impl) 2))
-                                    (uiop:pathname-parent-directory-pathname asdf:*user-cache*)))
-                                  (namestring pathname))
-                          0))))
-          (let* ((directories (nthcdr (length (pathname-directory asdf:*user-cache*))
-                                      (pathname-directory pathname)))
-                 (device (pathname-device pathname))
-                 (device (when (and device (not (eq device :unspecific)))
-                           (pop directories))))
-            (make-pathname
-             :type "lisp"
-             :defaults pathname
-             :device device
-             :directory (cons :absolute directories)))
-          (uiop:lispize-pathname pathname)))))
+      ;; Determine the actual cache root: prefer the dynamically probed root
+      ;; (which honours ASDF_OUTPUT_TRANSLATIONS) over *user-cache*.
+      (let* ((cache-root (or (effective-fasl-cache-root)
+                             asdf:*user-cache*)))
+        (unless cache-root
+          (return pathname))
+        (let* ((fasl-str (namestring pathname))
+               (impl (uiop:implementation-identifier))
+               (multithread-root
+                 ;; UIOP may add a -s suffix for multithreaded SBCL.  Some FASLs
+                 ;; were compiled under the suffix-less variant of the cache dir.
+                 ;; Use cache-root (not *user-cache*) as the base so that custom
+                 ;; ASDF_OUTPUT_TRANSLATIONS are respected here too.
+                 (when (and (uiop:featurep :sb-thread)
+                            (multithread-suffix-p impl))
+                   (merge-pathnames
+                    (subseq impl 0 (- (length impl) 2))
+                    (uiop:pathname-parent-directory-pathname cache-root))))
+               (match-root
+                 (cond
+                   ((eql (search (namestring cache-root) fasl-str) 0)
+                    cache-root)
+                   ((and multithread-root
+                         (eql (search (namestring multithread-root) fasl-str) 0))
+                    multithread-root))))
+          (if match-root
+              (let* ((directories (nthcdr (length (pathname-directory match-root))
+                                          (pathname-directory pathname)))
+                     (device (pathname-device pathname))
+                     (device (when (and device (not (eq device :unspecific)))
+                               (pop directories))))
+                (if (or device directories)
+                    (make-pathname
+                     :type "lisp"
+                     :defaults pathname
+                     :device device
+                     :directory (cons :absolute directories))
+                    (uiop:lispize-pathname pathname)))
+              (progn
+                (warn "resolve-file: could not map FASL ~A back to its source file. ~
+                       ASDF_OUTPUT_TRANSLATIONS may point to a location that rove's ~
+                       cache-root probe did not detect.  Run with a uniform single-rule ~
+                       output translation or ensure *user-cache* is set."
+                      pathname)
+                (uiop:lispize-pathname pathname))))))))
+
 
 (defun system-component-p (system-name component-name)
   (and (< (length system-name) (length component-name))

--- a/core/suite/file.lisp
+++ b/core/suite/file.lisp
@@ -15,36 +15,36 @@
        (<= 2 (length impl))
        (string= impl "-s" :start1 (- (length impl) 2))))
 
-;; Cached result of computing the ASDF output translation root.
-;; :not-computed means the value has not been determined yet.
-(defvar *effective-fasl-cache-root* :not-computed)
-
 (defun effective-fasl-cache-root ()
   "Return the root directory under which ASDF stores compiled files
 according to the current output translation configuration.
 When ASDF_OUTPUT_TRANSLATIONS points to a custom cache, this returns that
 custom root rather than the default asdf:*user-cache*.
-Returns nil if the translation appears to be an identity (no separate cache).
+Returns nil if the translation appears to be an identity (no separate cache)
+or if the ASDF probe signals an error.
 
 The probe pathname is intentionally one directory component deep so that
 butlast peeling exactly (length source-comps) components isolates the prefix.
-This assumes a single uniform translation rule applies to all source files."
-  (when (eq *effective-fasl-cache-root* :not-computed)
-    (setf *effective-fasl-cache-root*
-          (handler-case
-              (let* ((probe (make-pathname :directory '(:absolute "rove--fasl-probe")
-                                           :name "probe" :type "lisp"))
-                     (translated (asdf:apply-output-translations probe))
-                     (source-comps (cdr (pathname-directory probe)))
-                     (trans-comps (cdr (pathname-directory translated)))
-                     (cache-comps (butlast trans-comps (length source-comps))))
-                (when (and cache-comps (every #'stringp cache-comps))
-                  (make-pathname :directory (cons :absolute cache-comps)
-                                 :name nil :type nil :version nil
-                                 :defaults translated)))
-            (error ()
-              nil))))
-  *effective-fasl-cache-root*)
+This assumes a single uniform translation rule applies to all source files.
+
+Not memoized: called once per compiled file during load, and ASDF output
+translations may be reconfigured during an interactive session."
+  (handler-case
+      (let* ((probe (make-pathname :directory '(:absolute "rove--fasl-probe")
+                                   :name "probe" :type "lisp"))
+             (translated (asdf:apply-output-translations probe))
+             (source-comps (cdr (pathname-directory probe)))
+             (trans-comps (cdr (pathname-directory translated)))
+             (cache-comps (butlast trans-comps (length source-comps))))
+        (when (and cache-comps (every #'stringp cache-comps))
+          (make-pathname :directory (cons :absolute cache-comps)
+                         :name nil :type nil :version nil
+                         :defaults translated)))
+    (error (e)
+      (warn "effective-fasl-cache-root: ASDF output translation probe failed: ~A. ~
+             Falling back to asdf:*user-cache*."
+            e)
+      nil)))
 
 (defun resolve-file (pathname)
   (block nil

--- a/core/suite/file.lisp
+++ b/core/suite/file.lisp
@@ -15,6 +15,14 @@
        (<= 2 (length impl))
        (string= impl "-s" :start1 (- (length impl) 2))))
 
+;; Rate-limit the ASDF probe error warning so a permanently broken
+;; ASDF configuration does not flood *error-output* with one warning
+;; per compiled file.  Reset on image restore so a corrected image
+;; produces the warning again if the probe subsequently fails.
+(defvar *translation-probe-warned* nil)
+(uiop:register-image-restore-hook
+  (lambda () (setf *translation-probe-warned* nil)) t)
+
 (defun effective-fasl-cache-root ()
   "Return the root directory under which ASDF stores compiled files
 according to the current output translation configuration.
@@ -41,9 +49,11 @@ translations may be reconfigured during an interactive session."
                          :name nil :type nil :version nil
                          :defaults translated)))
     (error (e)
-      (warn "effective-fasl-cache-root: ASDF output translation probe failed: ~A. ~
-             Falling back to asdf:*user-cache*."
-            e)
+      (unless *translation-probe-warned*
+        (setf *translation-probe-warned* t)
+        (warn "effective-fasl-cache-root: ASDF output translation probe failed: ~A. ~
+               Falling back to asdf:*user-cache*."
+              e))
       nil)))
 
 (defun resolve-file (pathname)


### PR DESCRIPTION
## What

Add `effective-fasl-cache-root` to `core/suite/file.lisp` that probes `asdf:apply-output-translations` to find the actual FASL cache root, and update `resolve-file` to use it instead of always falling back to `asdf:*user-cache*`.

Also adds a rate-limited warning when the probe fails or when a FASL cannot be mapped back to its source file, to avoid flooding `*error-output*` in broken configurations.

## Why

`asdf:*user-cache*` is not updated when `ASDF_OUTPUT_TRANSLATIONS` is configured to redirect compiled files to a custom location. The old prefix check in `resolve-file` always compared against the default user cache, so every FASL path under a custom cache failed the match. rove fell through to `uiop:lispize-pathname`, which left the path pointing inside the cache dir rather than the source tree — causing `file-package` lookups to miss and `system-packages` to return nil, with the result that `run-system` discovered 0 tests.

The probe feeds a synthetic one-directory-deep path through `asdf:apply-output-translations` and computes how many extra directory components appeared in the result; those extra components are the cache root prefix. This avoids parsing `ASDF_OUTPUT_TRANSLATIONS` directly and correctly handles both the default cache and arbitrary custom translations.